### PR TITLE
Handle invalid tool call args

### DIFF
--- a/src/llm_bridge/responses.py
+++ b/src/llm_bridge/responses.py
@@ -62,12 +62,15 @@ class OpenAIResponse(BaseChatResponse):
 
                     if isinstance(raw_args, dict):
                         arguments = raw_args
-                    elif isinstance(raw_args, str) and raw_args.strip(): # Ensure string is not empty
+                    elif isinstance(raw_args, str) and raw_args.strip():  # Ensure string is not empty
                         try:
                             arguments = json.loads(raw_args)
                         except json.JSONDecodeError as exc:
-                            self._logger.warning(f"Bad JSON in tool call: {raw_args}", exc_info=exc)
-                            return None
+                            self._logger.warning(
+                                f"Bad JSON in tool call: {raw_args}", exc_info=exc
+                            )
+                            # Keep processing other tool calls instead of aborting
+                            arguments = {}
                     
                     calls.append(
                         ToolCallRequest(

--- a/tests/test_openai_response.py
+++ b/tests/test_openai_response.py
@@ -1,0 +1,37 @@
+import sys
+import pathlib
+import pytest
+
+# Ensure the src directory is on the path for importing llm_bridge modules directly
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+from llm_bridge.responses import OpenAIResponse
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function as ToolCallFunction,
+)
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.chat.chat_completion import ChatCompletion, Choice
+
+def test_invalid_tool_call_arguments_returns_empty_dict_instead_of_none():
+    bad_json = '{not valid json'
+
+    function = ToolCallFunction(name='test', arguments=bad_json)
+    tool_call = ChatCompletionMessageToolCall(id='id1', type='function', function=function)
+    message = ChatCompletionMessage(role='assistant', tool_calls=[tool_call])
+    choice = Choice(finish_reason='stop', index=0, message=message)
+    completion = ChatCompletion(
+        id='cmpl-1',
+        choices=[choice],
+        created=0,
+        model='gpt-4',
+        object='chat.completion',
+    )
+
+    response = OpenAIResponse(raw_response=completion)
+    tool_calls = response.get_tool_calls()
+
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].id == 'id1'
+    assert tool_calls[0].name == 'test'
+    assert tool_calls[0].arguments == {}


### PR DESCRIPTION
## Summary
- handle invalid JSON arguments in OpenAI tool calls without aborting
- add regression test for OpenAIResponse tool call parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cda294ff8832782ef9f58d01770bb